### PR TITLE
Prefer File to have it's own spec version than relying on Client Version

### DIFF
--- a/client/proposals-asset-system.md
+++ b/client/proposals-asset-system.md
@@ -35,7 +35,7 @@ The metadata file contains necessary information for the client to determine how
     "author": "The Vignette Authors",
     "version": {
         "asset": "1.0.0",
-        "client": "2022.201.0-github"
+        "spec": "1.0.0"
     },
     "permissions": [
         "tracking",
@@ -56,6 +56,6 @@ The metadata file contains necessary information for the client to determine how
 |`id`|The unique identifier for this asset.|
 |`name`|The display name for this asset.|
 |`author`|The display name for the author for this asset.|
-|`version`|An object describing the asset's version and the required client version. <table><th>Key</th><th>Value</th><tr><td>`asset`</td><td>The asset's version in semantic versioning format.</td></tr><tr><td>`client`</td><td>The client version in semantic versioning format.</td></tr></table>|
+|`version`|An object describing the asset's version and the required client version. <table><th>Key</th><th>Value</th><tr><td>`asset`</td><td>The asset's version in semantic versioning format.</td></tr><tr><td>`spec`</td><td>The asset specification version in semantic versioning format.</td></tr></table>|
 |`permissions`| An array of strings determining what aspects of the client scripts will need access to.|
 |`dependencies`| An array of objects determining the dependencies of this asset. The asset will not be loaded if a dependency is not found.<table><th>Key</th><th>Value</th><tr><td>`id`</td><td>The dependency asset's unique identifier.</td></tr><tr><td>`version`</td><td>The dependency asset's version in semantic versioning format.</td></tr></table>|


### PR DESCRIPTION
There are many reasons we want a specification version tied to the metadata instead of using the client version:

* This reduces the maintenance burden on the maintainers since they don't need to release a new version just to be compatible with a new version.
* This also allows us to do backwards compatibility by just defining a minimum spec version to implement but also allow to move forward by revising the implementation when we can via this specification document.
* Since our specification will be under community scrutiny, expect the specification document to update more often than the actual implementation.